### PR TITLE
Easy setup, auto download missing SD files..

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Compile with Partition Scheme: `Minimal SPIFFS (...)`.  and with PSRAM enabled.
 using [Boards Manager](https://github.com/s60sc/ESP32-CAM_MJPEG2SD/issues/61#issuecomment-1034928567)**
 
 The application web pages and configuration data file (except passwords) are stored in the **/data** folder which needs to be copied as a folder to the SD card.
-This reduces the size of the application on flash and reduces wear as well as making updates easier.
+This reduces the size of the application on flash and reduces wear as well as making updates easier. The web pages will be downloaded **automatically** to the SD card on first run if a valid wifi connection is set (with access to the internet).
 Subsequent updates to the application, or to the **/data** folder contents, can be made using the **OTA Upload** button on the web page.
 
 On first use, the application will start in wifi AP mode to allow router and other details to be entered via the web page, unless default values have been entered for the `ST_*` variables in `utils.cpp`.

--- a/data/configs.txt
+++ b/data/configs.txt
@@ -1,4 +1,3 @@
-ST_SSID:null
 ae_level:0
 aec:1
 aec2:1

--- a/myConfig.h
+++ b/myConfig.h
@@ -112,7 +112,8 @@
 #include <Update.h>
 #include <WebServer.h>
 #include <WiFi.h>
-
+#include <HTTPClient.h>
+#include <WiFiClientSecure.h>
 /******************** Function declarations *******************/
 
 // global app specific functions
@@ -171,8 +172,7 @@ bool startWifi();
 void syncToBrowser(const char *val);
 void getUpTime(char* timeVal);
 void urlDecode(char* inVal);
-
-
+void wgetFile(String url, String dir);
 /******************** Global utility declarations *******************/
 
 extern String AP_SSID;

--- a/utils.cpp
+++ b/utils.cpp
@@ -247,13 +247,33 @@ bool changeExtension(char* outName, const char* inName, const char* newExt) {
   outName[inNamePtr + extLen] = 0;
   return (inNamePtr > 1) ? true : false;
 }
-
+void checkSDFiles(){
+    //Check and download missing sd card files
+    if(!SD_MMC.exists(DATA_DIR)) SD_MMC.mkdir(DATA_DIR);
+    //No config map.. Download it
+    File f = SD_MMC.open("/data/configs.txt",FILE_READ);
+    bool bConfigOK = f && f.size()>0 ;
+    f.close();
+    if( !bConfigOK && WiFi.status() == WL_CONNECTED ){
+      LOG_INF("Invalid config file");
+      wgetFile("https://raw.githubusercontent.com/s60sc/ESP32-CAM_MJPEG2SD/master/data/configs.txt", DATA_DIR);
+      doRestart();
+    }
+    if(!SD_MMC.exists("/data/MJPEG2SD.htm"))
+      wgetFile("https://raw.githubusercontent.com/s60sc/ESP32-CAM_MJPEG2SD/master/data/MJPEG2SD.htm", DATA_DIR);      
+    if(!SD_MMC.exists("/data/jquery.min.js"))
+      wgetFile("https://raw.githubusercontent.com/s60sc/ESP32-CAM_MJPEG2SD/master/data/jquery.min.js", DATA_DIR);
+    if(!SD_MMC.exists("/data/OTA.htm"))
+      wgetFile("https://raw.githubusercontent.com/s60sc/ESP32-CAM_MJPEG2SD/master/data/OTA.htm", DATA_DIR);
+    if(!SD_MMC.exists("/data/LOG.htm"))
+      wgetFile("https://raw.githubusercontent.com/s60sc/ESP32-CAM_MJPEG2SD/master/data/LOG.htm", DATA_DIR);
+}
 bool startSpiffs() {
   if( !SPIFFS.begin(true)) {
     LOG_ERR("SPIFFS not mounted");
     return false;
   } else {
-    LOG_INF("SPIFFS: Total bytes %d, Used bytes %d", SPIFFS.totalBytes(), SPIFFS.usedBytes());
+    checkSDFiles();
     
     // list details of files on SPIFFS
     File root = SPIFFS.open("/");
@@ -262,6 +282,7 @@ bool startSpiffs() {
       LOG_INF("File: %s, size: %u", file.path(), file.size());
       file = root.openNextFile();
     }
+    LOG_INF("SPIFFS: Total bytes %d, Used bytes %d", SPIFFS.totalBytes(), SPIFFS.usedBytes());
     LOG_INF("Sketch size %d kB", ESP.getSketchSize() / 1024);
     return true;
   }
@@ -293,6 +314,63 @@ void urlDecode(char* inVal) {
   strcpy(inVal, replaceVal.c_str());
 }
 
+const char* git_rootCACertificate = \
+"-----BEGIN CERTIFICATE-----\n" \
+"MIIEsTCCA5mgAwIBAgIQBOHnpNxc8vNtwCtCuF0VnzANBgkqhkiG9w0BAQsFADBs\n" \
+"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n" \
+"d3cuZGlnaWNlcnQuY29tMSswKQYDVQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5j\n" \
+"ZSBFViBSb290IENBMB4XDTEzMTAyMjEyMDAwMFoXDTI4MTAyMjEyMDAwMFowcDEL\n" \
+"MAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3\n" \
+"LmRpZ2ljZXJ0LmNvbTEvMC0GA1UEAxMmRGlnaUNlcnQgU0hBMiBIaWdoIEFzc3Vy\n" \
+"YW5jZSBTZXJ2ZXIgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2\n" \
+"4C/CJAbIbQRf1+8KZAayfSImZRauQkCbztyfn3YHPsMwVYcZuU+UDlqUH1VWtMIC\n" \
+"Kq/QmO4LQNfE0DtyyBSe75CxEamu0si4QzrZCwvV1ZX1QK/IHe1NnF9Xt4ZQaJn1\n" \
+"itrSxwUfqJfJ3KSxgoQtxq2lnMcZgqaFD15EWCo3j/018QsIJzJa9buLnqS9UdAn\n" \
+"4t07QjOjBSjEuyjMmqwrIw14xnvmXnG3Sj4I+4G3FhahnSMSTeXXkgisdaScus0X\n" \
+"sh5ENWV/UyU50RwKmmMbGZJ0aAo3wsJSSMs5WqK24V3B3aAguCGikyZvFEohQcft\n" \
+"bZvySC/zA/WiaJJTL17jAgMBAAGjggFJMIIBRTASBgNVHRMBAf8ECDAGAQH/AgEA\n" \
+"MA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw\n" \
+"NAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2Vy\n" \
+"dC5jb20wSwYDVR0fBEQwQjBAoD6gPIY6aHR0cDovL2NybDQuZGlnaWNlcnQuY29t\n" \
+"L0RpZ2lDZXJ0SGlnaEFzc3VyYW5jZUVWUm9vdENBLmNybDA9BgNVHSAENjA0MDIG\n" \
+"BFUdIAAwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQ\n" \
+"UzAdBgNVHQ4EFgQUUWj/kK8CB3U8zNllZGKiErhZcjswHwYDVR0jBBgwFoAUsT7D\n" \
+"aQP4v0cB1JgmGggC72NkK8MwDQYJKoZIhvcNAQELBQADggEBABiKlYkD5m3fXPwd\n" \
+"aOpKj4PWUS+Na0QWnqxj9dJubISZi6qBcYRb7TROsLd5kinMLYBq8I4g4Xmk/gNH\n" \
+"E+r1hspZcX30BJZr01lYPf7TMSVcGDiEo+afgv2MW5gxTs14nhr9hctJqvIni5ly\n" \
+"/D6q1UEL2tU2ob8cbkdJf17ZSHwD2f2LSaCYJkJA69aSEaRkCldUxPUd1gJea6zu\n" \
+"xICaEnL6VpPX/78whQYwvwt/Tv9XBZ0k7YXDK/umdaisLRbvfXknsuvCnQsH6qqF\n" \
+"0wGjIChBWUMo0oHjqvbsezt3tkBigAVBRQHvFwY+3sAzm2fTYS5yh+Rp/BIAV0Ae\n" \
+"cPUeybQ=\n" \
+"-----END CERTIFICATE-----\n";
+  
+void wgetFile(String url, String dir){
+  if (WiFi.status() != WL_CONNECTED) return;  
+  String file_name=url.substring(url.lastIndexOf('/'));
+  String ff = "" + dir + "" + file_name;
+  //LOG_INF("Downloading %s",ff.c_str());
+  File f = SD_MMC.open(ff, "w+");
+  if( f ){
+    HTTPClient https;
+    WiFiClientSecure wclient;
+    wclient.setCACert(git_rootCACertificate);
+    https.begin(wclient, url);
+    LOG_INF("Downloading %s",ff.c_str());    
+    int httpCode = https.GET();
+    if (httpCode > 0 && httpCode == HTTP_CODE_OK) {
+        https.writeToStream(&f);
+        f.close();
+        LOG_INF("Downloaded %s", ff.c_str());        
+    }else{
+        f.close();
+        SD_MMC.remove(ff);
+        LOG_ERR("Download failed, error: %s", https.errorToString(httpCode).c_str());        
+    }    
+    https.end();
+  }else{
+    LOG_ERR("Open failed: %s ", ff.c_str());
+  }
+}
 void listBuff (const uint8_t* b, size_t len) {
   // output buffer content as hex, 16 bytes per line
   if (!len || !b) LOG_WRN("Nothing to print");


### PR DESCRIPTION
Hi..
I've made some modifications that allow quick setup of ESP32-CAM_MJPEG2SD on first run, if an internet connection is present.
If camera start in access point mode (not WL_CONNECTED) and an empty SD card found (missing data folder and web files), a minimal web page will be displayed instead of `file not found` message. This page will allow the configuration of the Wifi credentials, so device can be connected to the internet. On reboot if internet connection is established the SD card will be checked and missing files will be automatically downloaded from github to data folder.

Thanks