### PR TITLE
Updates for MQTT

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -184,6 +184,7 @@ void wsAsyncSend(const char* wsData);
 void startMqttClient();  
 void stopMqttClient();  
 void mqttPublish(const char* payload);
+void mqttPublishPath(const char* suffix, const char* payload);
 // telegram.cpp
 bool getTgramUpdate(char* response);
 bool sendTgramMessage(const char* info, const char* item, const char* parseMode);

--- a/prefs.cpp
+++ b/prefs.cpp
@@ -61,6 +61,12 @@ void showConfigVect() {
 
 void reloadConfigs() {
   while (getNextKeyVal()) updateStatus(variable, value);
+#if INCLUDE_MQTT
+  if (mqtt_active) {
+    buildJsonString(1);
+    mqttPublishPath("config", jsonBuff);
+  }
+#endif
 }
 
 static int getKeyPos(std::string thisKey) {
@@ -227,13 +233,6 @@ void updateStatus(const char* variable, const char* _value) {
   bool res = true;
   char value[IN_FILE_NAME_LEN];
   strncpy(value, _value, sizeof(value));  
-#if INCLUDE_MQTT
-  if (mqtt_active) {
-    char buff[(IN_FILE_NAME_LEN * 2)];
-    snprintf(buff, IN_FILE_NAME_LEN * 2, "%s=%s", variable, value);
-    mqttPublish(buff);
-  }
-#endif
 
   int intVal = atoi(value); 
   if (!strcmp(variable, "hostName")) strncpy(hostName, value, MAX_HOST_LEN-1);
@@ -301,8 +300,7 @@ void updateStatus(const char* variable, const char* _value) {
 #if INCLUDE_MQTT
   else if (!strcmp(variable, "mqtt_active")) {
     mqtt_active = (bool)intVal;
-    if (mqtt_active) startMqttClient();
-    else stopMqttClient();
+    if (!mqtt_active) stopMqttClient();
   } 
   else if (!strcmp(variable, "mqtt_broker")) strncpy(mqtt_broker, value, MAX_HOST_LEN-1);
   else if (!strcmp(variable, "mqtt_port")) strncpy(mqtt_port, value, 4);


### PR DESCRIPTION
Hey just found the repo and working great for me, although ran into some problems with MQTT.  Seems to be a timing issue with startMqttClient called from statusCheck & updateStatus that can run it twice before `mqttConnected` is updated:

```
[00:00:06.184 startMqttClient] Mqtt connect to mqtt://10.10.10.3:1883...
[00:00:06.186 startMqttClient] Created mqtt task: 1
[00:00:06.235 startMqttClient] Mqtt connect to mqtt://10.10.10.3:1883...
[00:00:06.236 startMqttClient] Created mqtt task: 1
```

Resetting the initial mqtt_client could cause the topic subscription to fail, which then calls stopMqttClient and starts the process over.  This fixes https://github.com/s60sc/ESP32-CAM_MJPEG2SD/issues/316.  I also changed reloadConfigs to send all the vars as json to a config topic, leaving the status topic mainly for motion events.  

If this works for you I could also take a look at the updates for arduino-esp32 v3. Thx!