### PR TITLE
Replace the time zone abbreviation with GMT to correct webdav

### DIFF
--- a/webDav.cpp
+++ b/webDav.cpp
@@ -60,7 +60,7 @@ static int getMimeType(const char* path) {
 static void formatTime(time_t t) {
   // format time for XML property values
   tm* timeinfo = gmtime(&t);
-  strftime(formattedTime, sizeof(formattedTime), "%a, %d %b %Y %H:%M:%S %Z", timeinfo);
+  strftime(formattedTime, sizeof(formattedTime), "%a, %d %b %Y %H:%M:%S GMT", timeinfo);
 }
 
 static bool haveResource(bool ignore = false) {


### PR DESCRIPTION
If webDave.cpp on function 

static void formatTime(time_t t) 

strftime(formattedTime, sizeof(formattedTime), "%a, %d %b %Y %H:%M:%S %Z", gmtime(&rawtime));

This uses the %Z directive, which automatically appends the time zone abbreviation of the struct tm passed to strftime.
My esp32cam time zone is 
EET-2EEST,M3.5.0/3,M10.5.0/4
so 
If rawtime = 2025-01-15 12:00:00, output → Wed, 15 Jan 2025 12:00:00 EET
If rawtime = 2025-07-15 12:00:00, output → Tue, 15 Jul 2025 12:00:00 EEST

With this format webdav is not working on Windows 10 beacause in HTTP headers (like Date), the format is always in GMT.

So the correct usage is:
strftime(formattedTime, sizeof(formattedTime), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&rawtime));

Use gmtime() to convert to UTC and then hardcode "GMT".

That fixes the problem..
Thanks
