### PR TITLE
trivial checkMotion() tweak

### DIFF
--- a/motionDetect.cpp
+++ b/motionDetect.cpp
@@ -287,6 +287,8 @@ bool checkMotion(camera_fb_t* fb, bool motionStatus, bool lightLevelOnly) {
         changeMap[(i * stride) + 2] = pixVal;
         for (int j = 0; j < RGB888_BYTES - 1; j++) changeMap[(i * stride) + j] = 0;
       }
+      // on this branch moving threshold may hit - escape earlier
+      if (changeCount > moveThreshold) break;
     }
   }
 


### PR DESCRIPTION
leave loop as earlier as pixel threshold hit.
has sense to speedup decision for high thresholds and massive updates. ideal place to leave after increment but want to keep original debug code.

tested on esp32s3 sense.